### PR TITLE
to not pin minor version of httpoison to reduce conflict

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Plaid.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 1.4.0"},
+      {:httpoison, "~> 1.4"},
       {:poison, "~> 3.0"},
       {:jason, "~> 1.1"},
       {:bypass, "~> 0.8", only: [:test]},


### PR DESCRIPTION
This allows v1.5 and above(<v2) of httpoison to be resolved.