### PR TITLE
Allow runtime config of root_uri too

### DIFF
--- a/lib/plaid/categories.ex
+++ b/lib/plaid/categories.ex
@@ -24,8 +24,9 @@ defmodule Plaid.Categories do
   Gets all categories.
   """
   @spec get() :: {:ok, Plaid.Categories.t()} | {:error, Plaid.Error.t()}
-  def get do
-    endpoint = "#{@endpoint}/get"
+  def get(config \\ %{}) do
+    root_uri = Map.get(config, :root_uri)
+    endpoint = "#{root_uri}#{@endpoint}/get"
 
     Plaid.make_request(:post, endpoint)
     |> Plaid.Utils.handle_resp(@endpoint)


### PR DESCRIPTION
We're running into a situation where, in the same app, we need to have some users hit the `sandbox` while others hit `development`. I'm not 100% happy with this solution, but I tested it in `iex` and it did work.