### PR TITLE
Runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ By default, `root_uri` is set by `mix` environment. You can override it in your 
 Finally, you can pass in custom configuration for [HTTPoison](https://github.com/edgurgel/httpoison). It's recommended you
 extend the receive timeout for Plaid, especially for retrieving historical transactions.
 
+## Runtime configuration
+
+You can overwrite the configuration at runtime.
+
+For example, if you want to hit a different URL when calling the `/accounts` endpoint, you could
+pass in a configuration argument to `Plaid.Accounts.get/2`.
+
+```elixir
+Plaid.Accounts.get(%{access_token: "my-token"}, %{root_uri: "http://sandbox.plaid.com/", secret: "no-secrets"})
+```
+
 ## Obtaining Access Tokens
 
 Access tokens are required for almost all calls to Plaid. However, they can only be obtained

--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -63,14 +63,6 @@ defmodule Plaid do
   end
 
   @doc """
-  Gets root URI from configuration.
-  """
-  @spec get_root_uri() :: map | no_return
-  def get_root_uri do
-    require_root_uri()
-  end
-
-  @doc """
   Makes request without credentials.
   """
   @spec make_request(atom, String.t(), map, map, Keyword.t()) ::
@@ -86,7 +78,7 @@ defmodule Plaid do
           {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
   def make_request_with_cred(method, endpoint, config, body \\ %{}, headers \\ %{}, options \\ []) do
     {root_uri, cred} = Map.pop(config, :root_uri)
-    re = "#{root_uri}#{endpoint}"
+    re = "#{root_uri || require_root_uri()}#{endpoint}"
     rb = Map.merge(body, cred) |> Poison.encode!()
     rh = get_request_headers() |> Map.merge(headers) |> Map.to_list()
     options = httpoison_request_options() ++ options
@@ -118,9 +110,9 @@ defmodule Plaid do
   end
 
   defp require_root_uri do
-    case Application.get_env(:plaid, :root_uri, :not_found) do
+    case Application.get_env(:plaid, :root_uri) || :not_found do
       :not_found -> raise MissingRootUriError
-      value -> %{root_uri: value}
+      value -> value
     end
   end
 

--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -67,6 +67,7 @@ defmodule Plaid do
   """
   @spec make_request(atom, String.t(), map, map, Keyword.t()) ::
           {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+  @deprecated "Use make_request_with_cred/3. This function doesn't allow runtime configuration of the root_uri."
   def make_request(method, endpoint, body \\ %{}, headers \\ %{}, options \\ []) do
     make_request_with_cred(method, endpoint, %{}, body, headers, options)
   end

--- a/lib/plaid/accounts.ex
+++ b/lib/plaid/accounts.ex
@@ -16,7 +16,7 @@ defmodule Plaid.Accounts do
           request_id: String.t()
         }
   @type params :: %{required(atom) => String.t() | map}
-  @type cred :: %{required(atom) => String.t()}
+  @type config :: %{required(atom) => String.t()}
 
   @endpoint :accounts
 
@@ -74,11 +74,12 @@ defmodule Plaid.Accounts do
   %{access_token: "access-token"}
   ```
   """
-  @spec get(params, cred | nil) :: {:ok, Plaid.Accounts.t()} | {:error, Plaid.Error.t()}
-  def get(params, cred \\ get_cred()) do
+  @spec get(params, config | nil) :: {:ok, Plaid.Accounts.t()} | {:error, Plaid.Error.t()}
+  def get(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/get"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
@@ -90,11 +91,12 @@ defmodule Plaid.Accounts do
   %{access_token: "access-token", options: %{account_ids: ["account-id"]}}
   ```
   """
-  @spec get_balance(params, cred | nil) :: {:ok, Plaid.Accounts.t()} | {:error, Plaid.Error.t()}
-  def get_balance(params, cred \\ get_cred()) do
+  @spec get_balance(params, config | nil) :: {:ok, Plaid.Accounts.t()} | {:error, Plaid.Error.t()}
+  def get_balance(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/balance/get"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 end

--- a/lib/plaid/auth.ex
+++ b/lib/plaid/auth.ex
@@ -22,7 +22,7 @@ defmodule Plaid.Auth do
             optional(:account_ids) => [String.t()]
           }
         }
-  @type cred :: %{required(atom) => String.t()}
+  @type config :: %{required(atom) => String.t()}
 
   @endpoint :auth
 
@@ -71,12 +71,13 @@ defmodule Plaid.Auth do
   }
   ```
   """
-  @spec get(params, cred | nil) :: {:ok, Plaid.Auth.t()} | {:error, Plaid.Error.t()}
-  def get(params, cred \\ get_cred()) do
+  @spec get(params, config | nil) :: {:ok, Plaid.Auth.t()} | {:error, Plaid.Error.t()}
+  def get(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/get"
 
     :post
-    |> make_request_with_cred(endpoint, cred, params)
+    |> make_request_with_cred(endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 end

--- a/lib/plaid/categories.ex
+++ b/lib/plaid/categories.ex
@@ -7,6 +7,7 @@ defmodule Plaid.Categories do
   defstruct categories: [], request_id: nil
 
   @type t :: %__MODULE__{categories: [Plaid.Categories.Category.t()], request_id: String.t()}
+  @type config :: %{required(atom) => String.t()}
 
   @endpoint :categories
 
@@ -23,11 +24,11 @@ defmodule Plaid.Categories do
   @doc """
   Gets all categories.
   """
-  @spec get() :: {:ok, Plaid.Categories.t()} | {:error, Plaid.Error.t()}
-  def get do
+  @spec get(config | nil) :: {:ok, Plaid.Categories.t()} | {:error, Plaid.Error.t()}
+  def get(config \\ %{}) do
     endpoint = "#{@endpoint}/get"
 
-    Plaid.make_request(:post, endpoint)
+    Plaid.make_request_with_cred(:post, endpoint, config)
     |> Plaid.Utils.handle_resp(@endpoint)
   end
 end

--- a/lib/plaid/income.ex
+++ b/lib/plaid/income.ex
@@ -18,7 +18,7 @@ defmodule Plaid.Income do
   @type params :: %{
           required(:access_token) => String.t()
         }
-  @type cred :: %{required(atom) => String.t()}
+  @type config :: %{required(atom) => String.t()}
 
   @endpoint :income
 
@@ -73,12 +73,13 @@ defmodule Plaid.Income do
   }
   ```
   """
-  @spec get(params, cred | nil) :: {:ok, Plaid.Income.t()} | {:error, Plaid.Error.t()}
-  def get(params, cred \\ get_cred()) do
+  @spec get(params, config | nil) :: {:ok, Plaid.Income.t()} | {:error, Plaid.Error.t()}
+  def get(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/get"
 
     :post
-    |> make_request_with_cred(endpoint, cred, params)
+    |> make_request_with_cred(endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 end

--- a/lib/plaid/institutions.ex
+++ b/lib/plaid/institutions.ex
@@ -16,8 +16,7 @@ defmodule Plaid.Institutions do
           total: integer
         }
   @type params :: %{required(atom) => integer | String.t() | list}
-  @type cred :: %{required(atom) => String.t()}
-  @type key :: %{public_key: String.t()}
+  @type config :: %{required(atom) => String.t()}
 
   @endpoint :institutions
 
@@ -110,24 +109,26 @@ defmodule Plaid.Institutions do
   %{count: 50, offset: 0}
   ```
   """
-  @spec get(params, cred | nil) :: {:ok, Plaid.Institutions.t()} | {:error, Plaid.Error.t()}
-  def get(params, cred \\ get_cred()) do
+  @spec get(params, config | nil) :: {:ok, Plaid.Institutions.t()} | {:error, Plaid.Error.t()}
+  def get(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/get"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
   @doc """
   Gets an institution by id.
   """
-  @spec get_by_id(String.t(), key | nil) ::
+  @spec get_by_id(String.t(), config | nil) ::
           {:ok, Plaid.Institutions.Institution.t()} | {:error, Plaid.Error.t()}
-  def get_by_id(id, key \\ get_key()) do
+  def get_by_id(id, config \\ %{}) do
+    config = Map.merge(get_key(), config)
     params = %{institution_id: id}
     endpoint = "#{@endpoint}/get_by_id"
 
-    make_request_with_cred(:post, endpoint, key, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(:institution)
   end
 
@@ -139,11 +140,12 @@ defmodule Plaid.Institutions do
   %{query: "Wells", products: ["transactions"], options: %{limit: 40, include_display_data: true}}
   ```
   """
-  @spec search(params, key | nil) :: {:ok, Plaid.Institutions.t()} | {:error, Plaid.Error.t()}
-  def search(params, key \\ get_key()) do
+  @spec search(params, config | nil) :: {:ok, Plaid.Institutions.t()} | {:error, Plaid.Error.t()}
+  def search(params, config \\ %{}) do
+    config = Map.merge(get_key(), config)
     endpoint = "#{@endpoint}/search"
 
-    make_request_with_cred(:post, endpoint, key, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 end

--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -26,7 +26,7 @@ defmodule Plaid.Item do
           request_id: String.t()
         }
   @type params :: %{required(atom) => String.t()}
-  @type cred :: %{required(atom) => String.t()}
+  @type config :: %{required(atom) => String.t()}
 
   @endpoint :item
 
@@ -38,11 +38,12 @@ defmodule Plaid.Item do
   %{access_token: "access-env-identifier"}
   ```
   """
-  @spec get(params, cred | nil) :: {:ok, Plaid.Item.t()} | {:error, Plaid.Error.t()}
-  def get(params, cred \\ get_cred()) do
+  @spec get(params, config | nil) :: {:ok, Plaid.Item.t()} | {:error, Plaid.Error.t()}
+  def get(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/get"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
@@ -59,11 +60,12 @@ defmodule Plaid.Item do
   {:ok, %{access_token: "access-env-identifier", item_id: "some-id", request_id: "f24wfg"}}
   ```
   """
-  @spec exchange_public_token(params, cred | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
-  def exchange_public_token(params, cred \\ get_cred()) do
+  @spec exchange_public_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def exchange_public_token(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/public_token/exchange"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
@@ -80,11 +82,12 @@ defmodule Plaid.Item do
   {:ok, %{public_token: "access-env-identifier", expiration: 3600, request_id: "kg414f"}}
   ```
   """
-  @spec create_public_token(params, cred | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
-  def create_public_token(params, cred \\ get_cred()) do
+  @spec create_public_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def create_public_token(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/public_token/create"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
@@ -96,11 +99,12 @@ defmodule Plaid.Item do
   %{access_webhook: "access-env-identifier", webhook: "http://mywebsite/api"}
   ```
   """
-  @spec update_webhook(params, cred | nil) :: {:ok, Plaid.Item.t()} | {:error, Plaid.Error.t()}
-  def update_webhook(params, cred \\ get_cred()) do
+  @spec update_webhook(params, config | nil) :: {:ok, Plaid.Item.t()} | {:error, Plaid.Error.t()}
+  def update_webhook(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/webhook/update"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
@@ -117,11 +121,12 @@ defmodule Plaid.Item do
   {:ok, %{new_access_token: "access-env-identifier", request_id: "gag8fs"}}
   ```
   """
-  @spec rotate_access_token(params, cred | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
-  def rotate_access_token(params, cred \\ get_cred()) do
+  @spec rotate_access_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def rotate_access_token(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/access_token/invalidate"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
@@ -138,11 +143,12 @@ defmodule Plaid.Item do
   {:ok, %{access_token: "access-env-identifier", item_id: "some-id", request_id: "f24wfg"}}
   ```
   """
-  @spec update_version_access_token(params, cred | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
-  def update_version_access_token(params, cred \\ get_cred()) do
+  @spec update_version_access_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def update_version_access_token(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/access_token/update_version"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
@@ -154,11 +160,12 @@ defmodule Plaid.Item do
   %{access_token: "access-env-identifier"}
   ```
   """
-  @spec delete(params, cred | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
-  def delete(params, cred \\ get_cred()) do
+  @spec delete(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def delete(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/delete"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 
@@ -176,11 +183,12 @@ defmodule Plaid.Item do
   {:ok, %{processor_token: "some-token", request_id: "k522f2"}}
   ```
   """
-  @spec create_processor_token(params, cred | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
-  def create_processor_token(params, cred \\ get_cred()) do
+  @spec create_processor_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def create_processor_token(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "processor/dwolla/processor_token/create"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 end

--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -143,7 +143,8 @@ defmodule Plaid.Item do
   {:ok, %{access_token: "access-env-identifier", item_id: "some-id", request_id: "f24wfg"}}
   ```
   """
-  @spec update_version_access_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  @spec update_version_access_token(params, config | nil) ::
+          {:ok, map} | {:error, Plaid.Error.t()}
   def update_version_access_token(params, config \\ %{}) do
     config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/access_token/update_version"

--- a/lib/plaid/transactions.ex
+++ b/lib/plaid/transactions.ex
@@ -18,7 +18,7 @@ defmodule Plaid.Transactions do
           request_id: String.t()
         }
   @type params :: %{required(atom) => String.t() | map}
-  @type cred :: %{required(atom) => String.t()}
+  @type config :: %{required(atom) => String.t()}
 
   @endpoint :transactions
 
@@ -124,11 +124,12 @@ defmodule Plaid.Transactions do
   }
   ```
   """
-  @spec get(params, cred | nil) :: {:ok, Plaid.Transactions.t()} | {:error, Plaid.Error.t()}
-  def get(params, cred \\ get_cred()) do
+  @spec get(params, config | nil) :: {:ok, Plaid.Transactions.t()} | {:error, Plaid.Error.t()}
+  def get(params, config \\ %{}) do
+    config = Map.merge(get_cred(), config)
     endpoint = "#{@endpoint}/get"
 
-    make_request_with_cred(:post, endpoint, cred, params)
+    make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
 end

--- a/test/lib/plaid_test.exs
+++ b/test/lib/plaid_test.exs
@@ -58,6 +58,39 @@ defmodule PlaidTest do
       Plaid.make_request_with_cred(:post, "any", %{client_id: "id", secret: "shhhh"})
     end
 
+    test "make_request_with_cred/3 uses root_uri in configuration if not passed in config", %{bypass: bypass} do
+      Bypass.expect(bypass, fn conn ->
+        assert "localhost" == conn.host
+        assert "/any" == conn.request_path
+        Plug.Conn.resp(conn, 200, "{\"status\":\"ok\"}")
+      end)
+
+      Plaid.make_request_with_cred(:post, "any", %{})
+    end
+
+    test "make_request_with_cred/3 merges credentials from configuration if empty config argument is passed", %{bypass: bypass} do
+      Application.put_env(:plaid, :client_id, "my_id")
+      Application.put_env(:plaid, :secret, "no_secrets")
+      Bypass.expect(bypass, fn conn ->
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        assert "POST" == conn.method
+        assert "{\"secret\":\"no_secrets\",\"client_id\":\"my_id\"}" == body
+        Plug.Conn.resp(conn, 200, "{\"status\":\"ok\"}")
+      end)
+
+      Plaid.make_request_with_cred(:post, "any", %{})
+    end
+
+    test "make_request_with_cred/3 uses root_uri value if provided in config argument", %{bypass: bypass} do
+      Bypass.expect(bypass, fn conn ->
+        assert "0.0.0.0" == conn.host
+        assert "/any" == conn.request_path
+        Plug.Conn.resp(conn, 200, "{\"status\":\"ok\"}")
+      end)
+
+      Plaid.make_request_with_cred(:post, "any", %{root_uri: "http://0.0.0.0:#{bypass.port}/"})
+    end
+
     test "make_request/2 sets headers correctly", %{bypass: bypass} do
       Bypass.expect(bypass, fn conn ->
         content_type =

--- a/test/lib/plaid_test.exs
+++ b/test/lib/plaid_test.exs
@@ -68,19 +68,6 @@ defmodule PlaidTest do
       Plaid.make_request_with_cred(:post, "any", %{})
     end
 
-    test "make_request_with_cred/3 merges credentials from configuration if empty config argument is passed", %{bypass: bypass} do
-      Application.put_env(:plaid, :client_id, "my_id")
-      Application.put_env(:plaid, :secret, "no_secrets")
-      Bypass.expect(bypass, fn conn ->
-        {:ok, body, _conn} = Plug.Conn.read_body(conn)
-        assert "POST" == conn.method
-        assert "{\"secret\":\"no_secrets\",\"client_id\":\"my_id\"}" == body
-        Plug.Conn.resp(conn, 200, "{\"status\":\"ok\"}")
-      end)
-
-      Plaid.make_request_with_cred(:post, "any", %{})
-    end
-
     test "make_request_with_cred/3 uses root_uri value if provided in config argument", %{bypass: bypass} do
       Bypass.expect(bypass, fn conn ->
         assert "0.0.0.0" == conn.host

--- a/test/lib/plaid_test.exs
+++ b/test/lib/plaid_test.exs
@@ -58,7 +58,9 @@ defmodule PlaidTest do
       Plaid.make_request_with_cred(:post, "any", %{client_id: "id", secret: "shhhh"})
     end
 
-    test "make_request_with_cred/3 uses root_uri in configuration if not passed in config", %{bypass: bypass} do
+    test "make_request_with_cred/3 uses root_uri in configuration if not passed in config", %{
+      bypass: bypass
+    } do
       Bypass.expect(bypass, fn conn ->
         assert "localhost" == conn.host
         assert "/any" == conn.request_path
@@ -68,7 +70,9 @@ defmodule PlaidTest do
       Plaid.make_request_with_cred(:post, "any", %{})
     end
 
-    test "make_request_with_cred/3 uses root_uri value if provided in config argument", %{bypass: bypass} do
+    test "make_request_with_cred/3 uses root_uri value if provided in config argument", %{
+      bypass: bypass
+    } do
       Bypass.expect(bypass, fn conn ->
         assert "0.0.0.0" == conn.host
         assert "/any" == conn.request_path


### PR DESCRIPTION
Allow users the flexibility to pass in the root_uri at runtime and better handling of credentials passed in at runtime.