### PR TITLE
Use the right field name for investment transaction ids

### DIFF
--- a/lib/plaid/investments/transactions.ex
+++ b/lib/plaid/investments/transactions.ex
@@ -34,7 +34,7 @@ defmodule Plaid.Investments.Transactions do
     """
 
     @derive Jason.Encoder
-    defstruct transaction_id: nil,
+    defstruct investment_transaction_id: nil,
               account_id: nil,
               security_id: nil,
               date: nil,
@@ -49,7 +49,7 @@ defmodule Plaid.Investments.Transactions do
               cancel_transaction_id: nil
 
     @type t :: %__MODULE__{
-            transaction_id: String.t(),
+            investment_transaction_id: String.t(),
             account_id: String.t(),
             security_id: String.t() | nil,
             date: String.t(),


### PR DESCRIPTION
So after on-the-field testing, it turns out Plaid had a minor discrepancy between their documentation and what the API returns. 

The documentation says the investment transactions have a `transaction_id` field, but they actually come with an `investment_transaction_id`. Plaid has been informed and they'll be fixing the docs.

Since the test fixtures I added were based on raw API data, they didn't have to be changed :)