### PR TITLE
Fix Plaid.Institutions.params not including map as a valid value

### DIFF
--- a/lib/plaid/institutions.ex
+++ b/lib/plaid/institutions.ex
@@ -15,7 +15,7 @@ defmodule Plaid.Institutions do
           request_id: String.t(),
           total: integer
         }
-  @type params :: %{required(atom) => integer | String.t() | list}
+  @type params :: %{required(atom) => integer | String.t() | list | map}
   @type config :: %{required(atom) => String.t()}
 
   @endpoint :institutions


### PR DESCRIPTION
Dialyzer is complaining when I pass extra options to the institutions endpoints (which are supported and work, but the spec does not contemplate), ie:

`Plaid.Institutions.get(%{count: 20, offset: 0, options: %{country_codes: ["US"]}}`

As per plaid documentation: https://plaid.com/docs/#all-institutions