### PR TITLE
Add Stripe Bank Account Token Integration

### DIFF
--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -204,10 +204,11 @@ defmodule Plaid.Item do
 
   Response
   ```
-  {:ok, %{stripe_bank_account_token: "btok_Kb62HbBqrrvdf8pBsAdt", request_id: "[Unique request ID]"}
+  {:ok, %{stripe_bank_account_token: "btok_Kb62HbBqrrvdf8pBsAdt", request_id: "[Unique request ID]"}}
   ```
   """
-  @spec create_stripe_bank_account_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  @spec create_stripe_bank_account_token(params, config | nil) ::
+          {:ok, map} | {:error, Plaid.Error.t()}
   def create_stripe_bank_account_token(params, config \\ %{}) do
     config = validate_cred(config)
     endpoint = "processor/stripe/bank_account_token/create"

--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -192,4 +192,27 @@ defmodule Plaid.Item do
     make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
+
+  @doc """
+  [Creates a stripe bank account token](https://stripe.com/docs/ach)
+  used to create an authenticated funding source with Stripe.
+
+  Parameters
+  ```
+  %{access_token: "access-env-identifier", account_id: "plaid-account-id"}
+  ```
+
+  Response
+  ```
+  {:ok, %{stripe_bank_account_token: "btok_Kb62HbBqrrvdf8pBsAdt", request_id: "[Unique request ID]"}
+  ```
+  """
+  @spec create_stripe_bank_account_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def create_stripe_bank_account_token(params, config \\ %{}) do
+    config = validate_cred(config)
+    endpoint = "processor/stripe/bank_account_token/create"
+
+    make_request_with_cred(:post, endpoint, config, params)
+    |> Utils.handle_resp(@endpoint)
+  end
 end

--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -164,6 +164,14 @@ defmodule Plaid.Utils do
     end)
   end
 
+  def map_response(%{"stripe_bank_account_token" => _} = response, :item) do
+    response
+    |> Map.take(["stripe_bank_account_token", "request_id"])
+    |> Enum.reduce(%{}, fn {k, v}, acc ->
+      Map.put(acc, String.to_atom(k), v)
+    end)
+  end
+
   def map_response(response, :"investments/holdings") do
     Poison.Decode.decode(response,
       as: %Plaid.Investments.Holdings{

--- a/test/lib/plaid/item_test.exs
+++ b/test/lib/plaid/item_test.exs
@@ -128,5 +128,23 @@ defmodule Plaid.ItemTest do
 
       assert resp.processor_token
     end
+
+    test "create_stripe_bank_account_token/1 request POST and returns token", %{bypass: bypass} do
+      body = http_response_body(:stripe_bank_account_token)
+
+      Bypass.expect(bypass, fn conn ->
+        assert "POST" == conn.method
+        assert "processor/stripe/bank_account_token/create" == Enum.join(conn.path_info, "/")
+        Plug.Conn.resp(conn, 200, Poison.encode!(body))
+      end)
+
+      assert {:ok, resp} =
+               Plaid.Item.create_stripe_bank_account_token(%{
+                 access_token: "token",
+                 account_id: "id"
+               })
+
+      assert resp.processor_token
+    end
   end
 end

--- a/test/lib/plaid/item_test.exs
+++ b/test/lib/plaid/item_test.exs
@@ -144,7 +144,7 @@ defmodule Plaid.ItemTest do
                  account_id: "id"
                })
 
-      assert resp.processor_token
+      assert resp.stripe_bank_account_token
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -371,6 +371,13 @@ defmodule Plaid.Factory do
     }
   end
 
+  def http_response_body(:processor_token) do
+    %{
+      "stripe_bank_account_token" => "stripe-sandbox-asda9-a99c1-ca3g",
+      "request_id" => "45QSn"
+    }
+  end
+
   def http_response_body(:"investments/transactions") do
     %{
       "accounts" => [

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -371,7 +371,7 @@ defmodule Plaid.Factory do
     }
   end
 
-  def http_response_body(:processor_token) do
+  def http_response_body(:stripe_bank_account_token) do
     %{
       "stripe_bank_account_token" => "stripe-sandbox-asda9-a99c1-ca3g",
       "request_id" => "45QSn"


### PR DESCRIPTION
Add integration to hit Stripe's `processor/stripe/bank_account_token/create` endpoint and create a stripe bank account token from a Plaid access token.