### PR TITLE
Decode nested identity structs

### DIFF
--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -120,7 +120,23 @@ defmodule Plaid.Utils do
   end
 
   def map_response(response, :identity) do
-    Poison.Decode.decode(response, as: %Plaid.Identity{})
+    Poison.Decode.decode(response,
+      as: %Plaid.Identity{
+        item: %Plaid.Item{},
+        accounts: [
+          %Plaid.Accounts.Account{
+            balances: %Plaid.Accounts.Account.Balance{},
+            owners: [
+              %Plaid.Accounts.Account.Owner{
+                addresses: [%Plaid.Accounts.Account.Owner.Address{}],
+                emails: [%Plaid.Accounts.Account.Owner.Email{}],
+                phone_numbers: [%Plaid.Accounts.Account.Owner.PhoneNumber{}]
+              }
+            ]
+          }
+        ]
+      }
+    )
   end
 
   def map_response(%{"item" => item} = response, :item) do


### PR DESCRIPTION
Includes the nested structs when decoding the Plaid Identity response, something I missed in my previous PR to include support for Identity.