### PR TITLE
Add item status

### DIFF
--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -14,7 +14,8 @@ defmodule Plaid.Item do
             institution_id: nil,
             item_id: nil,
             webhook: nil,
-            request_id: nil
+            request_id: nil,
+            status: nil
 
   @type t :: %__MODULE__{
           available_products: [String.t()],
@@ -23,7 +24,8 @@ defmodule Plaid.Item do
           institution_id: String.t(),
           item_id: String.t(),
           webhook: String.t(),
-          request_id: String.t()
+          request_id: String.t(),
+          status: map | nil,
         }
   @type params :: %{required(atom) => String.t()}
   @type config :: %{required(atom) => String.t()}

--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -120,7 +120,7 @@ defmodule Plaid.Utils do
   end
 
   def map_response(%{"item" => item} = response, :item) do
-    new_response = response |> Map.take(["request_id"]) |> Map.merge(item)
+    new_response = response |> Map.take(["request_id", "status"]) |> Map.merge(item)
     Poison.Decode.decode(new_response, as: %Plaid.Item{})
   end
 

--- a/test/lib/plaid/item_test.exs
+++ b/test/lib/plaid/item_test.exs
@@ -22,6 +22,7 @@ defmodule Plaid.ItemTest do
       assert {:ok, resp} = Plaid.Item.get(%{access_token: "my-token"})
       assert Plaid.Item == resp.__struct__
       assert {:ok, _} = Jason.encode(resp)
+      assert resp.status == body["status"]
     end
 
     test "exchange_public_token/1 requests POST and returns map", %{bypass: bypass} do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -79,7 +79,14 @@ defmodule Plaid.Factory do
         "item_id" => "Ed6bjNrDLJfGvZWwnkQlfxwoNz54B5C97ejBr",
         "webhook" => "https://plaid.com/example/hook"
       },
-      "request_id" => "qpCtl"
+      "request_id" => "qpCtl",
+      "status" => %{
+        "last_webhook" => nil,
+        "transactions" => %{
+          "last_failed_update" => nil,
+          "last_successful_update" => "2020-05-19T23:16:55.038Z"
+        }
+      }
     }
   end
 


### PR DESCRIPTION
An Item's status is a field on a Plaid Item that gives important information about when it was last updated.

Right now `plaid-elixir` doesn't expose this field on the Item. This adds it there.

Many other popular open-source libraries for Plaid (such as [plaid-python](https://github.com/plaid/plaid-python)) support this.