### PR TITLE
Support other services' processor tokens

### DIFF
--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -29,6 +29,7 @@ defmodule Plaid.Item do
         }
   @type params :: %{required(atom) => String.t()}
   @type config :: %{required(atom) => String.t()}
+  @type service :: :dwolla | :modern_treasury
 
   @endpoint :item
 
@@ -233,14 +234,37 @@ defmodule Plaid.Item do
   {:ok, %{processor_token: "some-token", request_id: "k522f2"}}
   ```
   """
+  @deprecated "Use create_processor_token/3 instead"
   @spec create_processor_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
   def create_processor_token(params, config \\ %{}) do
+    create_processor_token(params, :dwolla, config)
+  end
+
+  @doc """
+  Creates a processor token used to integrate with services external to Plaid.
+
+  Parameters
+  ```
+  %{access_token: "access-env-identifier", account_id: "plaid-account-id"}
+  ```
+
+  Response
+  ```
+  {:ok, %{processor_token: "some-token", request_id: "k522f2"}}
+  ```
+  """
+  @spec create_processor_token(params, service, config | nil) ::
+          {:ok, map} | {:error, Plaid.Error.t()}
+  def create_processor_token(params, service, config) do
     config = validate_cred(config)
-    endpoint = "processor/dwolla/processor_token/create"
+    endpoint = "processor/#{service_to_string(service)}/processor_token/create"
 
     make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)
   end
+
+  defp service_to_string(:dwolla), do: "dwolla"
+  defp service_to_string(:modern_treasury), do: "modern_treasury"
 
   @doc """
   [Creates a stripe bank account token](https://stripe.com/docs/ach)

--- a/test/lib/plaid/item_test.exs
+++ b/test/lib/plaid/item_test.exs
@@ -119,7 +119,7 @@ defmodule Plaid.ItemTest do
       assert resp.deleted == body["deleted"]
     end
 
-    test "create_processor_token/1 request POST and returns token", %{bypass: bypass} do
+    test "deprecated: create_processor_token/1 request POST and returns token", %{bypass: bypass} do
       body = http_response_body(:processor_token)
 
       Bypass.expect(bypass, fn conn ->
@@ -130,6 +130,25 @@ defmodule Plaid.ItemTest do
 
       assert {:ok, resp} =
                Plaid.Item.create_processor_token(%{access_token: "token", account_id: "id"})
+
+      assert resp.processor_token
+    end
+
+    test "create_processor_token/3 request POST and returns token", %{bypass: bypass} do
+      body = http_response_body(:processor_token)
+
+      Bypass.expect(bypass, fn conn ->
+        assert "POST" == conn.method
+        assert "processor/dwolla/processor_token/create" == Enum.join(conn.path_info, "/")
+        Plug.Conn.resp(conn, 200, Poison.encode!(body))
+      end)
+
+      assert {:ok, resp} =
+               Plaid.Item.create_processor_token(
+                 %{access_token: "token", account_id: "id"},
+                 :dwolla,
+                 %{}
+               )
 
       assert resp.processor_token
     end


### PR DESCRIPTION
The old function `create_processor_token/2` does not allow to create processor tokens for other services like modern treasury while it can by just allowing to change the request path. Can we update this function and deprecate its former version?