### PR TITLE
Add Plaid Link Token support

### DIFF
--- a/lib/plaid/link.ex
+++ b/lib/plaid/link.ex
@@ -1,0 +1,47 @@
+defmodule Plaid.Link do
+  @moduledoc """
+  Functions for Plaid `link` endpoint.
+  """
+
+  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1]
+
+  alias Plaid.Utils
+
+  @derive Jason.Encoder
+  defstruct link_token: nil,
+            expiration: nil,
+            request_id: nil
+
+  @type t :: %__MODULE__{
+          link_token: String.t(),
+          expiration: String.t(),
+          request_id: String.t()
+        }
+  @type params :: %{required(atom) => String.t()}
+  @type config :: %{required(atom) => String.t()}
+
+  @endpoint :link
+
+  @doc """
+  Creates a Link Token.
+
+  Parameters
+  ```
+  %{
+    client_name: "",
+    language: "",
+    country_codes: "",
+    user: %{client_user_id: ""}
+  }
+  ```
+  """
+  @spec create_link_token(params, config | nil) ::
+          {:ok, Plaid.Link.t()} | {:error, Plaid.Error.t()}
+  def create_link_token(params, config \\ %{}) do
+    config = validate_cred(config)
+    endpoint = "#{@endpoint}/token/create"
+
+    make_request_with_cred(:post, endpoint, config, params)
+    |> Utils.handle_resp(@endpoint)
+  end
+end

--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -301,4 +301,13 @@ defmodule Plaid.Utils do
       }
     )
   end
+
+  def map_response(response, :link) do
+    Poison.Decode.transform(
+      response,
+      %{
+        as: %Plaid.Link{}
+      }
+    )
+  end
 end

--- a/test/lib/plaid/link_test.exs
+++ b/test/lib/plaid/link_test.exs
@@ -1,0 +1,35 @@
+defmodule Plaid.LinkTest do
+  use ExUnit.Case
+
+  import Plaid.Factory
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:plaid, :root_uri, "http://localhost:#{bypass.port}/")
+    {:ok, bypass: bypass}
+  end
+
+  test "create_link_token/1 request POST and returns map", %{bypass: bypass} do
+    body = http_response_body(:create_link_token)
+
+    Bypass.expect(bypass, fn conn ->
+      assert "POST" == conn.method
+      assert "link/token/create" == Enum.join(conn.path_info, "/")
+      Plug.Conn.resp(conn, 200, Poison.encode!(body))
+    end)
+
+    assert {:ok, resp} =
+             Plaid.Link.create_link_token(%{
+               client_name: "My App",
+               country_codes: ["US"],
+               language: "en",
+               products: ["transactions"],
+               user: %{client_user_id: "UNIQUE_USER_ID"},
+               webhook: "https://sample.webhook.com"
+             })
+
+    assert resp.link_token == body["link_token"]
+    assert resp.expiration == body["expiration"]
+    assert resp.request_id == body["request_id"]
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1538,4 +1538,12 @@ defmodule Plaid.Factory do
       request_id: "vnfz2k6XTtgjpbX"
     }
   end
+
+  def http_response_body(:create_link_token) do
+    %{
+      "link_token" => "link-sandbox-234a923f-8908-41de-a30e-354a3cd5dfef",
+      "expiration" => "2020-08-25T11:00:49Z",
+      "request_id" => "7mtxj0CIzYXiFq2"
+    }
+  end
 end


### PR DESCRIPTION
Added functionality for creating Plaid Link Tokens. https://plaid.com/docs/upgrade-to-link-tokens/

Wasn't sure if I should add this to the Plaid module or create a Plaid.Link module.
Wasn't sure what documentation I should change and if I should document only required params (or optional ones as well) for the token creation.