### PR TITLE
update delete endpoint with new name and response body

### DIFF
--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -206,17 +206,22 @@ defmodule Plaid.Item do
   end
 
   @doc """
-  Deletes an Item.
+  Removes an Item.
 
   Parameters
   ```
   %{access_token: "access-env-identifier"}
   ```
+
+  Response
+  ```
+  {:ok, %{request_id: "[Unique request ID]"}}
+  ```
   """
-  @spec delete(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
-  def delete(params, config \\ %{}) do
+  @spec remove(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def remove(params, config \\ %{}) do
     config = validate_cred(config)
-    endpoint = "#{@endpoint}/delete"
+    endpoint = "#{@endpoint}/remove"
 
     make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)

--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -242,14 +242,6 @@ defmodule Plaid.Utils do
     end)
   end
 
-  def map_response(%{"deleted" => _} = response, :item) do
-    response
-    |> Map.take(["deleted", "request_id"])
-    |> Enum.reduce(%{}, fn {k, v}, acc ->
-      Map.put(acc, String.to_atom(k), v)
-    end)
-  end
-
   def map_response(%{"processor_token" => _} = response, :item) do
     response
     |> Map.take(["processor_token", "request_id"])
@@ -261,6 +253,14 @@ defmodule Plaid.Utils do
   def map_response(%{"stripe_bank_account_token" => _} = response, :item) do
     response
     |> Map.take(["stripe_bank_account_token", "request_id"])
+    |> Enum.reduce(%{}, fn {k, v}, acc ->
+      Map.put(acc, String.to_atom(k), v)
+    end)
+  end
+
+  def map_response(%{"request_id" => _} = response, :item) do
+    response
+    |> Map.take(["request_id"])
     |> Enum.reduce(%{}, fn {k, v}, acc ->
       Map.put(acc, String.to_atom(k), v)
     end)

--- a/test/lib/plaid/item_test.exs
+++ b/test/lib/plaid/item_test.exs
@@ -106,17 +106,17 @@ defmodule Plaid.ItemTest do
       assert resp.access_token == body["access_token"]
     end
 
-    test "delete/1 requests POST and returns success", %{bypass: bypass} do
-      body = http_response_body(:delete)
+    test "remove/1 requests POST and returns success", %{bypass: bypass} do
+      body = http_response_body(:remove)
 
       Bypass.expect(bypass, fn conn ->
         assert "POST" == conn.method
-        assert "item/delete" == Enum.join(conn.path_info, "/")
+        assert "item/remove" == Enum.join(conn.path_info, "/")
         Plug.Conn.resp(conn, 200, Poison.encode!(body))
       end)
 
-      assert {:ok, resp} = Plaid.Item.delete(%{access_token: "my-token"})
-      assert resp.deleted == body["deleted"]
+      assert {:ok, resp} = Plaid.Item.remove(%{access_token: "my-token"})
+      assert resp.request_id == body["request_id"]
     end
 
     test "deprecated: create_processor_token/1 request POST and returns token", %{bypass: bypass} do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -163,9 +163,8 @@ defmodule Plaid.Factory do
     }
   end
 
-  def http_response_body(:delete) do
+  def http_response_body(:remove) do
     %{
-      "deleted" => true,
       "request_id" => "s72lQ"
     }
   end


### PR DESCRIPTION
Deleting an item raises an error due to `deleted: true` no longer being [part of the response body](https://plaid.com/docs/api/items/#itemremove). Now, `request_id` is the only item returned. Therefore if an item response is received that contains only a `request_id`, we assume it is a delete response after exhausting all other potential request body matches.

The item `delete` endpoint has also been updated to `remove` so this PR makes that change to mirror the Plaid API.