### PR TITLE
Fix type problem

### DIFF
--- a/lib/plaid/accounts.ex
+++ b/lib/plaid/accounts.ex
@@ -15,7 +15,7 @@ defmodule Plaid.Accounts do
           item: Plaid.Item.t(),
           request_id: String.t()
         }
-  @type params :: %{required(atom) => String.t() | map}
+  @type params :: %{required(atom) => String.t() | [String.t()] | map}
   @type config :: %{required(atom) => String.t()}
 
   @endpoint :accounts


### PR DESCRIPTION
There is a problem with types and when using function `Plaid.Accounts.get_balance/2` dialyzer will complain as we require field `account_ids` which value is a `[String.t()] | map()` while the successful typing for params values is only `String.t()`. This PR changes this.