### PR TITLE
Deprecate public key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ otp_release:
   - 19.3
   - 20.3
   - 21.2
-script:
-  - "MIX_ENV=test mix do deps.get, test && mix compile && mix coveralls.travis"
 matrix:
   allow_failures:
     - elixir: 1.8.0
@@ -16,3 +14,6 @@ matrix:
   exclude:
     - elixir: 1.8.0
       otp_release: 19.3
+env:
+  - MIX_ENV=test
+script: mix coveralls.travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ matrix:
 env:
   - MIX_ENV=test
 script: mix coveralls.travis
+

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ end
 
 ## Configuration
 
-All calls to Plaid require either your client id and secret, or public key. Add the
-following configuration to your project to set the values. This configuration is optional
+All calls to Plaid require your client id and secret. Public keys are deprecated as of version `2.4` of the upstream project.
+Add the following configuration to your project to set the values. This configuration is optional
 as of version `1.6`, see below for a runtime configuration. The library will raise an
 error if the relevant credentials are not provided either via `config.exs` or at runtime.
 

--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -122,6 +122,7 @@ defmodule Plaid do
   @doc """
   Gets the `public_key` from the config argument or library configuration.
   """
+  @deprecated "Plaid no longer uses public keys for new accounts."
   @spec validate_public_key(map) :: map | no_return
   def validate_public_key(config) do
     %{

--- a/lib/plaid/institutions.ex
+++ b/lib/plaid/institutions.ex
@@ -3,7 +3,7 @@ defmodule Plaid.Institutions do
   Functions for Plaid `institutions` endpoint.
   """
 
-  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1, validate_public_key: 1]
+  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1]
 
   alias Plaid.Utils
 
@@ -133,7 +133,7 @@ defmodule Plaid.Institutions do
   @spec get_by_id(String.t() | params, config | nil) ::
           {:ok, Plaid.Institutions.Institution.t()} | {:error, Plaid.Error.t()}
   def get_by_id(params, config \\ %{}) do
-    config = validate_public_key(config)
+    config = validate_cred(config)
     params = if is_binary(params), do: %{institution_id: params}, else: params
     endpoint = "#{@endpoint}/get_by_id"
 
@@ -151,7 +151,7 @@ defmodule Plaid.Institutions do
   """
   @spec search(params, config | nil) :: {:ok, Plaid.Institutions.t()} | {:error, Plaid.Error.t()}
   def search(params, config \\ %{}) do
-    config = validate_public_key(config)
+    config = validate_cred(config)
     endpoint = "#{@endpoint}/search"
 
     make_request_with_cred(:post, endpoint, config, params)

--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -14,7 +14,8 @@ defmodule Plaid.Item do
             institution_id: nil,
             item_id: nil,
             webhook: nil,
-            request_id: nil
+            request_id: nil,
+            status: nil
 
   @type t :: %__MODULE__{
           available_products: [String.t()],
@@ -23,7 +24,8 @@ defmodule Plaid.Item do
           institution_id: String.t(),
           item_id: String.t(),
           webhook: String.t(),
-          request_id: String.t()
+          request_id: String.t(),
+          status: map | nil,
         }
   @type params :: %{required(atom) => String.t()}
   @type config :: %{required(atom) => String.t()}

--- a/lib/plaid/link.ex
+++ b/lib/plaid/link.ex
@@ -1,0 +1,46 @@
+defmodule Plaid.Link do
+  @moduledoc """
+  Functions for Plaid `link` endpoint.
+  """
+
+  import Plaid, only: [make_request_with_cred: 4, validate_cred: 1]
+
+  alias Plaid.Utils
+
+  @derive Jason.Encoder
+  defstruct link_token: nil,
+            expiration: nil,
+            request_id: nil
+
+  @type t :: %__MODULE__{
+          link_token: String.t(),
+          expiration: String.t(),
+          request_id: String.t()
+        }
+  @type params :: %{required(atom) => String.t()}
+  @type config :: %{required(atom) => String.t()}
+
+  @endpoint :link
+
+  @doc """
+  Creates a Link Token.
+  Parameters
+  ```
+  %{
+    client_name: "",
+    language: "",
+    country_codes: "",
+    user: %{client_user_id: ""}
+  }
+  ```
+  """
+  @spec create_link_token(params, config | nil) ::
+          {:ok, Plaid.Link.t()} | {:error, Plaid.Error.t()}
+  def create_link_token(params, config \\ %{}) do
+    config = validate_cred(config)
+    endpoint = "#{@endpoint}/token/create"
+
+    make_request_with_cred(:post, endpoint, config, params)
+    |> Utils.handle_resp(@endpoint)
+  end
+end

--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -164,7 +164,7 @@ defmodule Plaid.Utils do
   end
 
   def map_response(%{"item" => item} = response, :item) do
-    new_response = response |> Map.take(["request_id"]) |> Map.merge(item)
+    new_response = response |> Map.take(["request_id", "status"]) |> Map.merge(item)
     Poison.Decode.transform(new_response, %{as: %Plaid.Item{}})
   end
 

--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -251,4 +251,13 @@ defmodule Plaid.Utils do
       }
     )
   end
+
+  def map_response(response, :link) do
+    Poison.Decode.transform(
+      response,
+      %{
+        as: %Plaid.Link{}
+      }
+    )
+  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -22,7 +22,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm", "00e3ebdc821fb3a36957320d49e8f4bfa310d73ea31c90e5f925dc75e030da8f"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "aa312d5df0f815eed879aaa77543534e21c78ca4a7e983083698fc190796fd9c"},
-  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm", "6e56493a862433fccc3aca3025c946d6720d8eedf6e3e6fb911952a7071c357f"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm", "603561dc0fd62f4f2ea9b890f4e20e1a0d388746d6e20557cafb1b16950de88c"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},

--- a/test/lib/plaid/link_test.exs
+++ b/test/lib/plaid/link_test.exs
@@ -1,0 +1,35 @@
+defmodule Plaid.LinkTest do
+  use ExUnit.Case
+
+  import Plaid.Factory
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:plaid, :root_uri, "http://localhost:#{bypass.port}/")
+    {:ok, bypass: bypass}
+  end
+
+  test "create_link_token/1 request POST and returns map", %{bypass: bypass} do
+    body = http_response_body(:create_link_token)
+
+    Bypass.expect(bypass, fn conn ->
+      assert "POST" == conn.method
+      assert "link/token/create" == Enum.join(conn.path_info, "/")
+      Plug.Conn.resp(conn, 200, Poison.encode!(body))
+    end)
+
+    assert {:ok, resp} =
+             Plaid.Link.create_link_token(%{
+               client_name: "My App",
+               country_codes: ["US"],
+               language: "en",
+               products: ["transactions"],
+               user: %{client_user_id: "UNIQUE_USER_ID"},
+               webhook: "https://sample.webhook.com"
+             })
+
+    assert resp.link_token == body["link_token"]
+    assert resp.expiration == body["expiration"]
+    assert resp.request_id == body["request_id"]
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1406,4 +1406,12 @@ defmodule Plaid.Factory do
       request_id: "vnfz2k6XTtgjpbX"
     }
   end
+
+  def http_response_body(:create_link_token) do
+    %{
+      "link_token" => "link-sandbox-234a923f-8908-41de-a30e-354a3cd5dfef",
+      "expiration" => "2020-08-25T11:00:49Z",
+      "request_id" => "7mtxj0CIzYXiFq2"
+    }
+  end
 end


### PR DESCRIPTION
Plaid has deprecated the use of the public key, and upstream changed to reflect that, this pull in the changes from https://github.com/wfgilman/plaid-elixir/commit/124ee49876895c3f6080d30dd5a38818607d1464