### PR TITLE
Add support for passing HTTPoison options

### DIFF
--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -87,15 +87,15 @@ defmodule Plaid do
           {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
   def make_request_with_cred(method, endpoint, config, body \\ %{}, headers \\ %{}, options \\ []) do
     request_endpoint = "#{get_root_uri(config)}#{endpoint}"
-
-    cred =
-      config
-      |> Map.delete(:root_uri)
-      |> Map.delete(:httpoison_options)
-
+    cred = Map.take(config, [:client_id, :secret])
     request_body = Map.merge(body, cred) |> Poison.encode!()
     request_headers = get_request_headers() |> Map.merge(headers) |> Map.to_list()
-    options = httpoison_request_options(config) ++ options
+    
+    options =
+      httpoison_request_options()
+      |> Keyword.merge(Map.get(config, :httpoison_options, []))
+      |> Keyword.merge(options)
+    
     request(method, request_endpoint, request_body, request_headers, options)
   end
 

--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -92,7 +92,7 @@ defmodule Plaid do
     request_headers = get_request_headers() |> Map.merge(headers) |> Map.to_list()
     
     options =
-      httpoison_request_options()
+      default_httpoison_request_options()
       |> Keyword.merge(Map.get(config, :httpoison_options, []))
       |> Keyword.merge(options)
     
@@ -108,8 +108,8 @@ defmodule Plaid do
     |> Map.put("Content-Type", "application/json")
   end
 
-  defp httpoison_request_options(config) do
-    Application.get_env(:plaid, :httpoison_options, []) ++ Map.get(config, :httpoison_options, [])
+  defp default_httpoison_request_options do
+    Application.get_env(:plaid, :httpoison_options, [])
   end
 
   @doc """

--- a/test/lib/plaid_test.exs
+++ b/test/lib/plaid_test.exs
@@ -41,7 +41,8 @@ defmodule PlaidTest do
       assert %{
                client_id: "me",
                secret: "shhhh",
-               root_uri: "http://localhost:1234/"
+               root_uri: "http://localhost:1234/",
+               httpoison_options: []
              } == Plaid.validate_cred(config)
     end
 
@@ -54,7 +55,8 @@ defmodule PlaidTest do
       assert %{
                client_id: "you",
                secret: "no secrets",
-               root_uri: "http://localhost:#{bypass.port}/"
+               root_uri: "http://localhost:#{bypass.port}/",
+               httpoison_options: []
              } == Plaid.validate_cred(%{})
     end
 


### PR DESCRIPTION
This allows for HTTPoison options to be passed through such as proxy or hackney values

```elixir
    http_opts = %{
      httpoison_options: [{:proxy, "https://localhost:9090"}]
    }
    Plaid.Link.create_link_token(%{
      client_name: "",
      country_codes: "US",
      user: %{client_user_id: ""}
    })

```

