### PR TITLE
Add extra telemetry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Metadata attached (if applicable to event type) are as follows:
 * `:exception` - The exception that was thrown during making the request.
 * `:result` - If no exception, contains either `{:ok, %HTTPoison.Response{}}` or `{:error, reason}`
 
+Additionally, you can pass your custom metadata through the `config` parameter when calling a product endpoint.
+Put it under `telemetry_metadata` and it will be merged to the standard metadata map.
+
 All times are in :native unit.
 
 ## Compatibility

--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -88,11 +88,12 @@ defmodule Plaid do
   @spec make_request_with_cred(atom, String.t(), map, map, map, Keyword.t()) ::
           {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
   def make_request_with_cred(method, endpoint, config, body \\ %{}, headers \\ %{}, options \\ []) do
-    common_metadata = %{
+    passed_metadata = config[:telemetry_metadata] || %{}
+    common_metadata = Map.merge(passed_metadata, %{
       method: method,
       path: endpoint,
       u: :native
-    }
+    })
 
     with_metrics(
       fn ->

--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -89,11 +89,13 @@ defmodule Plaid do
           {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
   def make_request_with_cred(method, endpoint, config, body \\ %{}, headers \\ %{}, options \\ []) do
     passed_metadata = config[:telemetry_metadata] || %{}
-    common_metadata = Map.merge(passed_metadata, %{
-      method: method,
-      path: endpoint,
-      u: :native
-    })
+
+    common_metadata =
+      Map.merge(passed_metadata, %{
+        method: method,
+        path: endpoint,
+        u: :native
+      })
 
     with_metrics(
       fn ->

--- a/test/lib/plaid_test.exs
+++ b/test/lib/plaid_test.exs
@@ -270,7 +270,8 @@ defmodule PlaidTest do
         Plug.Conn.resp(conn, 200, "{\"status\":\"ok\"}")
       end)
 
-      {:ok, _resp} = Plaid.make_request_with_cred(:get, "any", %{telemetry_metadata: %{ins_id: "ins_1"}})
+      {:ok, _resp} =
+        Plaid.make_request_with_cred(:get, "any", %{telemetry_metadata: %{ins_id: "ins_1"}})
 
       [start, stop] = receive_events(2)
 
@@ -278,7 +279,15 @@ defmodule PlaidTest do
       assert {@stop_event, %{duration: _}, stop_meta} = stop
 
       assert %{method: :get, path: "any", u: :native, ins_id: "ins_1"} = start_meta
-      assert %{method: :get, path: "any", status: 200, u: :native, result: {:ok, _}, ins_id: "ins_1"} = stop_meta
+
+      assert %{
+               method: :get,
+               path: "any",
+               status: 200,
+               u: :native,
+               result: {:ok, _},
+               ins_id: "ins_1"
+             } = stop_meta
     end
 
     defp receive_events(n, acc_events \\ [])

--- a/test/lib/plaid_test.exs
+++ b/test/lib/plaid_test.exs
@@ -217,12 +217,12 @@ defmodule PlaidTest do
       on_exit(fn -> :telemetry.detach(id) end)
     end
 
-    test "are sent on make_request/2", %{bypass: bypass} do
+    test "are sent on make_request_with_cred", %{bypass: bypass} do
       Bypass.expect(bypass, fn conn ->
         Plug.Conn.resp(conn, 200, "{\"status\":\"ok\"}")
       end)
 
-      {:ok, _resp} = Plaid.make_request(:get, "any")
+      {:ok, _resp} = Plaid.make_request_with_cred(:get, "any", %{})
 
       [start, stop] = receive_events(2)
 
@@ -236,7 +236,7 @@ defmodule PlaidTest do
     test "are sent when there's a lower level error", %{bypass: bypass} do
       Bypass.down(bypass)
 
-      {:error, _econnrefused} = Plaid.make_request(:get, "any")
+      {:error, _econnrefused} = Plaid.make_request_with_cred(:get, "any", %{})
 
       [start, stop] = receive_events(2)
 
@@ -251,7 +251,7 @@ defmodule PlaidTest do
       body = %{key: <<128>>}
 
       try do
-        Plaid.make_request(:get, "any", body)
+        Plaid.make_request_with_cred(:get, "any", %{}, body)
       rescue
         _ -> :ok
       end


### PR DESCRIPTION
Hey, @wfgilman, this is a small improvement I'm suggesting over my previous PR. I realized it would be nice to allow the user of the library to pass some extra information about the request. A good example of a use case is institution id. It might be nice to be able to break down errors that we get by institution that causes it.