### PR TITLE
Fix config validation to pass telemetry_metadata

### DIFF
--- a/lib/plaid.ex
+++ b/lib/plaid.ex
@@ -174,7 +174,8 @@ defmodule Plaid do
       client_id: get_client_id(config),
       secret: get_secret(config),
       root_uri: get_root_uri(config),
-      httpoison_options: Map.get(config, :httpoison_options, [])
+      httpoison_options: Map.get(config, :httpoison_options, []),
+      telemetry_metadata: Map.get(config, :telemetry_metadata, %{})
     }
   end
 

--- a/test/lib/plaid_test.exs
+++ b/test/lib/plaid_test.exs
@@ -42,7 +42,8 @@ defmodule PlaidTest do
                client_id: "me",
                secret: "shhhh",
                root_uri: "http://localhost:1234/",
-               httpoison_options: []
+               httpoison_options: [],
+               telemetry_metadata: %{}
              } == Plaid.validate_cred(config)
     end
 
@@ -56,7 +57,8 @@ defmodule PlaidTest do
                client_id: "you",
                secret: "no secrets",
                root_uri: "http://localhost:#{bypass.port}/",
-               httpoison_options: []
+               httpoison_options: [],
+               telemetry_metadata: %{}
              } == Plaid.validate_cred(%{})
     end
 
@@ -70,6 +72,18 @@ defmodule PlaidTest do
       Application.put_env(:plaid, :secret, nil)
       assert_raise Plaid.MissingSecretError, fn -> Plaid.validate_cred(%{client_id: "me"}) end
       cleanup_config()
+    end
+
+    test "validate_cred/1 preserves telemetry_metadata and httpoison_options" do
+      config = %{
+        httpoison_options: [some_key: "some_value"],
+        telemetry_metadata: %{ins_id: "ins_id"}
+      }
+
+      assert %{
+               httpoison_options: [some_key: "some_value"],
+               telemetry_metadata: %{ins_id: "ins_id"}
+             } = Plaid.validate_cred(config)
     end
 
     test "validate_public_key/1 uses configuration value when no config is passed as argument", %{


### PR DESCRIPTION
In my previous PR I didn't notice that valid_cred overwrites the config for each product. I made it pass through the telemetry_metadata key. Sorry for the inconvenience!