### PR TITLE
Add transactions personal_finance_category field

### DIFF
--- a/lib/plaid/transactions.ex
+++ b/lib/plaid/transactions.ex
@@ -67,7 +67,9 @@ defmodule Plaid.Transactions do
               merchant_name: nil,
               authorized_date: nil,
               payment_channel: nil,
-              transaction_code: nil
+              transaction_code: nil,
+              check_number: nil,
+              personal_finance_category: nil
 
     @type t :: %__MODULE__{
             account_id: String.t(),
@@ -88,7 +90,8 @@ defmodule Plaid.Transactions do
             merchant_name: String.t(),
             authorized_date: String.t(),
             payment_channel: String.t(),
-            transaction_code: String.t()
+            transaction_code: String.t(),
+            personal_finance_category: Plaid.Transactions.Transaction.PersonalFinanceCategory.t()
           }
 
     defmodule Location do
@@ -150,6 +153,21 @@ defmodule Plaid.Transactions do
               reference_number: String.t()
             }
     end
+
+    defmodule PersonalFinanceCategory do
+      @moduledoc """
+      Plaid Transaction Personal Finance Category data structure.
+      """
+
+      @derive Jason.Encoder
+      defstruct primary: nil,
+                detailed: nil
+
+      @type t :: %__MODULE__{
+              primary: String.t(),
+              detailed: String.t()
+            }
+    end
   end
 
   defmodule RemovedTransaction do
@@ -205,7 +223,8 @@ defmodule Plaid.Transactions do
           transactions: [
             %Plaid.Transactions.Transaction{
               location: %Plaid.Transactions.Transaction.Location{},
-              payment_meta: %Plaid.Transactions.Transaction.PaymentMeta{}
+              payment_meta: %Plaid.Transactions.Transaction.PaymentMeta{},
+              personal_finance_category: %Plaid.Transactions.Transaction.PersonalFinanceCategory{}
             }
           ],
           item: %Plaid.Item{}
@@ -245,13 +264,15 @@ defmodule Plaid.Transactions do
           added: [
             %Plaid.Transactions.Transaction{
               location: %Plaid.Transactions.Transaction.Location{},
-              payment_meta: %Plaid.Transactions.Transaction.PaymentMeta{}
+              payment_meta: %Plaid.Transactions.Transaction.PaymentMeta{},
+              personal_finance_category: %Plaid.Transactions.Transaction.PersonalFinanceCategory{}
             }
           ],
           modified: [
             %Plaid.Transactions.Transaction{
               location: %Plaid.Transactions.Transaction.Location{},
-              payment_meta: %Plaid.Transactions.Transaction.PaymentMeta{}
+              payment_meta: %Plaid.Transactions.Transaction.PaymentMeta{},
+              personal_finance_category: %Plaid.Transactions.Transaction.PersonalFinanceCategory{}
             }
           ],
           removed: [

--- a/test/lib/plaid/transactions_test.exs
+++ b/test/lib/plaid/transactions_test.exs
@@ -28,7 +28,9 @@ defmodule Plaid.TransactionsTest do
                transactions: [
                  %Plaid.Transactions.Transaction{
                    location: %Plaid.Transactions.Transaction.Location{},
-                   payment_meta: %Plaid.Transactions.Transaction.PaymentMeta{}
+                   payment_meta: %Plaid.Transactions.Transaction.PaymentMeta{},
+                   personal_finance_category:
+                     %Plaid.Transactions.Transaction.PersonalFinanceCategory{}
                  }
                ]
              })

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1716,8 +1716,7 @@ defmodule Plaid.Factory do
         }
       },
       "request_id" => "eYupqX1mZkEuQRx",
-      "warnings" => [
-        %{
+      "warnings" => [%{
           "warning_type" => "ASSET_REPORT_WARNING",
           "warning_code" => "OWNERS_UNAVAILABLE",
           "cause" => %{
@@ -1728,13 +1727,11 @@ defmodule Plaid.Factory do
             "request_id" => "Iam3b",
             "causes" => [],
             "status" => 400,
-            "documentation_url" =>
-              "https://plaid.com/docs/api/products/assets/#asset_reportcreate",
+            "documentation_url" => "https://plaid.com/docs/api/products/assets/#asset_reportcreate",
             "suggested_action" => "Please retry request",
             "item_id" => "eYupqX1mZkEuQRx"
           }
-        }
-      ]
+      }]
     }
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -469,6 +469,10 @@ defmodule Plaid.Factory do
           "payment_channel" => "in store",
           "pending" => false,
           "pending_transaction_id" => nil,
+          "personal_finance_category" => %{
+            "primary" => "GENERAL_MERCHANDISE",
+            "detailed" => "GENERAL_MERCHANDISE_ELECTRONICS"
+          },
           "account_owner" => nil,
           "transaction_id" => "lPNjeW1nR6CDn5okmGQ6hEpMo4lLNoSrzqDje",
           "transaction_code" => nil,
@@ -569,6 +573,10 @@ defmodule Plaid.Factory do
           },
           "pending" => false,
           "pending_transaction_id" => nil,
+          "personal_finance_category" => %{
+            "primary" => "GENERAL_MERCHANDISE",
+            "detailed" => "GENERAL_MERCHANDISE_ELECTRONICS"
+          },
           "transaction_code" => nil,
           "transaction_id" => "lPNjeW1nR6CDn5okmGQ6hEpMo4lLNoSrzqDje",
           "unofficial_currency_code" => nil
@@ -613,6 +621,10 @@ defmodule Plaid.Factory do
           },
           "pending" => false,
           "pending_transaction_id" => nil,
+          "personal_finance_category" => %{
+            "primary" => "RENT_AND_UTILITIES",
+            "detailed" => "RENT_AND_UTILITIES_GAS_AND_ELECTRICITY"
+          },
           "transaction_code" => nil,
           "transaction_id" => "yhnUVvtcGGcCKU0bcz8PDQr5ZUxUXebUvbKC0",
           "unofficial_currency_code" => nil
@@ -1704,7 +1716,8 @@ defmodule Plaid.Factory do
         }
       },
       "request_id" => "eYupqX1mZkEuQRx",
-      "warnings" => [%{
+      "warnings" => [
+        %{
           "warning_type" => "ASSET_REPORT_WARNING",
           "warning_code" => "OWNERS_UNAVAILABLE",
           "cause" => %{
@@ -1715,11 +1728,13 @@ defmodule Plaid.Factory do
             "request_id" => "Iam3b",
             "causes" => [],
             "status" => 400,
-            "documentation_url" => "https://plaid.com/docs/api/products/assets/#asset_reportcreate",
+            "documentation_url" =>
+              "https://plaid.com/docs/api/products/assets/#asset_reportcreate",
             "suggested_action" => "Please retry request",
             "item_id" => "eYupqX1mZkEuQRx"
           }
-      }]
+        }
+      ]
     }
   end
 end


### PR DESCRIPTION
Lightly summarizing [the transactions docs](https://plaid.com/docs/api/products/transactions/#transactions-sync-request-options-include-personal-finance-category), Plaid encourages all implementations to set the `include_personal_finance_category` option to `true` and use the new `personal_finance_category` field instead of the old `category` field, as it is intended to provide higher accuracy and more meaningful categories.

Implement the encoder for `PersonalFinanceCategory` and use it when decoding  responses from both `Transactions.get` and `Transactions.sync`. If the `include_personal_finance_category` option is not set in the request, the field remains `nil`, otherwise is is populated with the map containing the primary and detailed categories.