### PR TITLE
Add Identity Verification product support

### DIFF
--- a/lib/plaid/identity_verification.ex
+++ b/lib/plaid/identity_verification.ex
@@ -378,7 +378,7 @@ defmodule Plaid.IdentityVerification do
           }
   end
 
-  defmodule ListResponse do
+  defmodule Verifications do
     @moduledoc """
     Plaid Identity Verification List response data structure.
     """
@@ -466,7 +466,7 @@ defmodule Plaid.IdentityVerification do
   }
   ```
   """
-  @spec list(params, config) :: {:ok, Plaid.IdentityVerification.ListResponse.t()} | error
+  @spec list(params, config) :: {:ok, Plaid.IdentityVerification.Verifications.t()} | error
   def list(params, config \\ %{}) do
     c = config[:client] || Plaid
 
@@ -474,7 +474,7 @@ defmodule Plaid.IdentityVerification do
     |> struct(method: :post, endpoint: "identity_verification/list", body: params)
     |> Request.add_metadata(config)
     |> c.send_request(Client.new(config))
-    |> c.handle_response(&map_list_response(&1))
+    |> c.handle_response(&map_verifications(&1))
   end
 
   @doc """
@@ -540,11 +540,11 @@ defmodule Plaid.IdentityVerification do
     )
   end
 
-  defp map_list_response(body) do
+  defp map_verifications(body) do
     Poison.Decode.transform(
       body,
       %{
-        as: %Plaid.IdentityVerification.ListResponse{
+        as: %Plaid.IdentityVerification.Verifications{
           identity_verifications: [
             %Plaid.IdentityVerification{
               template: %Plaid.IdentityVerification.Template{},

--- a/lib/plaid/identity_verification.ex
+++ b/lib/plaid/identity_verification.ex
@@ -1,0 +1,589 @@
+defmodule Plaid.IdentityVerification do
+  @moduledoc """
+  Functions for Plaid `identity_verification` endpoint.
+
+  [Plaid Identity Verification API Documentation](https://plaid.com/docs/api/products/identity-verification/)
+  """
+
+  alias Plaid.Client.Request
+  alias Plaid.Client
+
+  @derive Jason.Encoder
+  defstruct id: nil,
+            client_user_id: nil,
+            created_at: nil,
+            completed_at: nil,
+            previous_attempt_id: nil,
+            shareable_url: nil,
+            status: nil,
+            template: nil,
+            user: nil,
+            steps: nil,
+            documentary_verification: nil,
+            selfie_check: nil,
+            kyc_check: nil,
+            risk_check: nil,
+            watchlist_screening: nil,
+            request_id: nil
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          client_user_id: String.t(),
+          created_at: String.t(),
+          completed_at: String.t() | nil,
+          previous_attempt_id: String.t() | nil,
+          shareable_url: String.t() | nil,
+          status: String.t(),
+          template: Plaid.IdentityVerification.Template.t(),
+          user: Plaid.IdentityVerification.User.t(),
+          steps: Plaid.IdentityVerification.Steps.t(),
+          documentary_verification: Plaid.IdentityVerification.DocumentaryVerification.t() | nil,
+          selfie_check: Plaid.IdentityVerification.SelfieCheck.t() | nil,
+          kyc_check: Plaid.IdentityVerification.KYCCheck.t() | nil,
+          risk_check: Plaid.IdentityVerification.RiskCheck.t() | nil,
+          watchlist_screening: Plaid.IdentityVerification.WatchlistScreening.t() | nil,
+          request_id: String.t()
+        }
+  @type params :: %{required(atom) => term}
+  @type config :: %{required(atom) => String.t() | keyword}
+  @type error :: {:error, Plaid.Error.t() | any()} | no_return
+
+  defmodule Template do
+    @moduledoc """
+    Plaid Identity Verification Template data structure.
+    """
+
+    @derive Jason.Encoder
+    defstruct id: nil, version: nil
+
+    @type t :: %__MODULE__{
+            id: String.t(),
+            version: integer()
+          }
+  end
+
+  defmodule User do
+    @moduledoc """
+    Plaid Identity Verification User data structure.
+    """
+
+    @derive Jason.Encoder
+    defstruct email_address: nil,
+              phone_number: nil,
+              date_of_birth: nil,
+              ip_address: nil,
+              name: nil,
+              address: nil,
+              id_number: nil
+
+    @type t :: %__MODULE__{
+            email_address: String.t() | nil,
+            phone_number: String.t() | nil,
+            date_of_birth: String.t() | nil,
+            ip_address: String.t() | nil,
+            name: Plaid.IdentityVerification.User.Name.t() | nil,
+            address: Plaid.IdentityVerification.User.Address.t() | nil,
+            id_number: Plaid.IdentityVerification.User.IDNumber.t() | nil
+          }
+
+    defmodule Name do
+      @moduledoc """
+      Plaid Identity Verification User Name data structure.
+      """
+
+      @derive Jason.Encoder
+      defstruct given_name: nil, family_name: nil
+
+      @type t :: %__MODULE__{
+              given_name: String.t(),
+              family_name: String.t()
+            }
+    end
+
+    defmodule Address do
+      @moduledoc """
+      Plaid Identity Verification User Address data structure.
+      """
+
+      @derive Jason.Encoder
+      defstruct street: nil,
+                street2: nil,
+                city: nil,
+                region: nil,
+                postal_code: nil,
+                country: nil
+
+      @type t :: %__MODULE__{
+              street: String.t(),
+              street2: String.t() | nil,
+              city: String.t(),
+              region: String.t(),
+              postal_code: String.t(),
+              country: String.t()
+            }
+    end
+
+    defmodule IDNumber do
+      @moduledoc """
+      Plaid Identity Verification User ID Number data structure.
+      """
+
+      @derive Jason.Encoder
+      defstruct value: nil, type: nil
+
+      @type t :: %__MODULE__{
+              value: String.t(),
+              type: String.t()
+            }
+    end
+  end
+
+  defmodule Steps do
+    @moduledoc """
+    Plaid Identity Verification Steps data structure.
+
+    Each step will be one of the following values: `active`, `success`, `failed`,
+    `waiting_for_prerequisite`, `not_applicable`, `skipped`, `expired`, `canceled`,
+    `pending_review`, `manually_approved`, or `manually_rejected`.
+    """
+
+    @derive Jason.Encoder
+    defstruct accept_tos: nil,
+              verify_sms: nil,
+              kyc_check: nil,
+              documentary_verification: nil,
+              selfie_check: nil,
+              watchlist_screening: nil,
+              risk_check: nil
+
+    @type t :: %__MODULE__{
+            accept_tos: String.t() | nil,
+            verify_sms: String.t() | nil,
+            kyc_check: String.t() | nil,
+            documentary_verification: String.t() | nil,
+            selfie_check: String.t() | nil,
+            watchlist_screening: String.t() | nil,
+            risk_check: String.t() | nil
+          }
+  end
+
+  defmodule DocumentaryVerification do
+    @moduledoc """
+    Plaid Identity Verification Documentary Verification data structure.
+    """
+
+    @derive Jason.Encoder
+    defstruct status: nil, documents: []
+
+    @type t :: %__MODULE__{
+            status: String.t(),
+            documents: [Plaid.IdentityVerification.DocumentaryVerification.Document.t()]
+          }
+
+    defmodule Document do
+      @moduledoc """
+      Plaid Identity Verification Document data structure.
+      """
+
+      @derive Jason.Encoder
+      defstruct status: nil,
+                attempt: nil,
+                images: [],
+                extracted_data: nil,
+                analysis: nil,
+                redacted_images: []
+
+      @type t :: %__MODULE__{
+              status: String.t(),
+              attempt: integer(),
+              images: [Plaid.IdentityVerification.DocumentaryVerification.Document.Image.t()],
+              extracted_data:
+                Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedData.t()
+                | nil,
+              analysis:
+                Plaid.IdentityVerification.DocumentaryVerification.Document.Analysis.t() | nil,
+              redacted_images: [
+                Plaid.IdentityVerification.DocumentaryVerification.Document.Image.t()
+              ]
+            }
+
+      defmodule Image do
+        @moduledoc """
+        Plaid Identity Verification Document Image data structure.
+        """
+
+        @derive Jason.Encoder
+        defstruct url: nil, capture_method: nil
+
+        @type t :: %__MODULE__{
+                url: String.t(),
+                capture_method: String.t()
+              }
+      end
+
+      defmodule ExtractedData do
+        @moduledoc """
+        Plaid Identity Verification Document Extracted Data data structure.
+        """
+
+        @derive Jason.Encoder
+        defstruct date_of_birth: nil,
+                  expiration_date: nil,
+                  issued_date: nil,
+                  issuing_country: nil,
+                  id_number: nil,
+                  category: nil,
+                  address: nil,
+                  name: nil
+
+        @type t :: %__MODULE__{
+                date_of_birth: String.t() | nil,
+                expiration_date: String.t() | nil,
+                issued_date: String.t() | nil,
+                issuing_country: String.t() | nil,
+                id_number: String.t() | nil,
+                category: String.t() | nil,
+                address: Plaid.IdentityVerification.User.Address.t() | nil,
+                name: Plaid.IdentityVerification.User.Name.t() | nil
+              }
+      end
+
+      defmodule Analysis do
+        @moduledoc """
+        Plaid Identity Verification Document Analysis data structure.
+        """
+
+        @derive Jason.Encoder
+        defstruct authenticity: nil,
+                  image_quality: nil,
+                  extracted_data: nil
+
+        @type t :: %__MODULE__{
+                authenticity: String.t() | nil,
+                image_quality: String.t() | nil,
+                extracted_data: String.t() | nil
+              }
+      end
+    end
+  end
+
+  defmodule SelfieCheck do
+    @moduledoc """
+    Plaid Identity Verification Selfie Check data structure.
+    """
+
+    @derive Jason.Encoder
+    defstruct status: nil,
+              attempt: nil,
+              capture: [],
+              analysis: nil
+
+    @type t :: %__MODULE__{
+            status: String.t(),
+            attempt: integer(),
+            capture: [Plaid.IdentityVerification.SelfieCheck.Capture.t()],
+            analysis: Plaid.IdentityVerification.SelfieCheck.Analysis.t() | nil
+          }
+
+    defmodule Capture do
+      @moduledoc """
+      Plaid Identity Verification Selfie Capture data structure.
+      """
+
+      @derive Jason.Encoder
+      defstruct url: nil, video_url: nil, capture_method: nil
+
+      @type t :: %__MODULE__{
+              url: String.t() | nil,
+              video_url: String.t() | nil,
+              capture_method: String.t()
+            }
+    end
+
+    defmodule Analysis do
+      @moduledoc """
+      Plaid Identity Verification Selfie Analysis data structure.
+      """
+
+      @derive Jason.Encoder
+      defstruct face_match: nil, image_quality: nil
+
+      @type t :: %__MODULE__{
+              face_match: String.t() | nil,
+              image_quality: String.t() | nil
+            }
+    end
+  end
+
+  defmodule KYCCheck do
+    @moduledoc """
+    Plaid Identity Verification KYC Check data structure.
+    """
+
+    @derive Jason.Encoder
+    defstruct status: nil,
+              address: nil,
+              name: nil,
+              date_of_birth: nil,
+              id_number: nil,
+              phone_number: nil
+
+    @type t :: %__MODULE__{
+            status: String.t(),
+            address: String.t() | nil,
+            name: String.t() | nil,
+            date_of_birth: String.t() | nil,
+            id_number: String.t() | nil,
+            phone_number: String.t() | nil
+          }
+  end
+
+  defmodule RiskCheck do
+    @moduledoc """
+    Plaid Identity Verification Risk Check data structure.
+    """
+
+    @derive Jason.Encoder
+    defstruct status: nil,
+              risk_score: nil,
+              linked_services: [],
+              behavior: nil,
+              email: nil,
+              phone: nil
+
+    @type t :: %__MODULE__{
+            status: String.t(),
+            risk_score: integer() | nil,
+            linked_services: [String.t()],
+            behavior: map() | nil,
+            email: map() | nil,
+            phone: map() | nil
+          }
+  end
+
+  defmodule WatchlistScreening do
+    @moduledoc """
+    Plaid Identity Verification Watchlist Screening data structure.
+    """
+
+    @derive Jason.Encoder
+    defstruct status: nil,
+              audit_trail: nil,
+              search_terms: nil
+
+    @type t :: %__MODULE__{
+            status: String.t(),
+            audit_trail: String.t() | nil,
+            search_terms: map() | nil
+          }
+  end
+
+  defmodule ListResponse do
+    @moduledoc """
+    Plaid Identity Verification List response data structure.
+    """
+
+    @derive Jason.Encoder
+    defstruct identity_verifications: [],
+              next_cursor: nil,
+              request_id: nil
+
+    @type t :: %__MODULE__{
+            identity_verifications: [Plaid.IdentityVerification.t()],
+            next_cursor: String.t() | nil,
+            request_id: String.t()
+          }
+  end
+
+  @doc """
+  Creates a new Identity Verification.
+
+  Parameters
+  ```
+  %{
+    template_id: "idvtmp_4FrXJvfQU3zGUR",
+    gave_consent: true,
+    is_shareable: true,
+    client_user_id: "your-db-id-3b24110",
+    user: %{
+      email_address: "user@example.com",
+      phone_number: "+1 415 555 0100",
+      date_of_birth: "1990-01-01",
+      name: %{
+        given_name: "John",
+        family_name: "Doe"
+      },
+      address: %{
+        street: "123 Main St",
+        city: "San Francisco",
+        region: "CA",
+        postal_code: "94108",
+        country: "US"
+      }
+    }
+  }
+  ```
+  """
+  @spec create(params, config) :: {:ok, Plaid.IdentityVerification.t()} | error
+  def create(params, config \\ %{}) do
+    c = config[:client] || Plaid
+
+    Request
+    |> struct(method: :post, endpoint: "identity_verification/create", body: params)
+    |> Request.add_metadata(config)
+    |> c.send_request(Client.new(config))
+    |> c.handle_response(&map_identity_verification(&1))
+  end
+
+  @doc """
+  Retrieves the details of an Identity Verification.
+
+  Parameters
+  ```
+  %{identity_verification_id: "idv_52xR9LKo77r1Np"}
+  ```
+  """
+  @spec get(params, config) :: {:ok, Plaid.IdentityVerification.t()} | error
+  def get(params, config \\ %{}) do
+    c = config[:client] || Plaid
+
+    Request
+    |> struct(method: :post, endpoint: "identity_verification/get", body: params)
+    |> Request.add_metadata(config)
+    |> c.send_request(Client.new(config))
+    |> c.handle_response(&map_identity_verification(&1))
+  end
+
+  @doc """
+  Lists Identity Verifications.
+
+  Parameters
+  ```
+  %{
+    template_id: "idvtmp_4FrXJvfQU3zGUR",
+    client_user_id: "your-db-id-3b24110",
+    cursor: "eyJkaXJlY3Rpb24iOiJuZXh0Iiwib2Zmc2V0IjoiMTU5NDM"
+  }
+  ```
+  """
+  @spec list(params, config) :: {:ok, Plaid.IdentityVerification.ListResponse.t()} | error
+  def list(params, config \\ %{}) do
+    c = config[:client] || Plaid
+
+    Request
+    |> struct(method: :post, endpoint: "identity_verification/list", body: params)
+    |> Request.add_metadata(config)
+    |> c.send_request(Client.new(config))
+    |> c.handle_response(&map_list_response(&1))
+  end
+
+  @doc """
+  Allows a user to retry an Identity Verification.
+
+  Parameters
+  ```
+  %{
+    client_user_id: "your-db-id-3b24110",
+    template_id: "idvtmp_4FrXJvfQU3zGUR",
+    strategy: "reset"
+  }
+  ```
+  """
+  @spec retry(params, config) :: {:ok, Plaid.IdentityVerification.t()} | error
+  def retry(params, config \\ %{}) do
+    c = config[:client] || Plaid
+
+    Request
+    |> struct(method: :post, endpoint: "identity_verification/retry", body: params)
+    |> Request.add_metadata(config)
+    |> c.send_request(Client.new(config))
+    |> c.handle_response(&map_identity_verification(&1))
+  end
+
+  defp map_identity_verification(body) do
+    Poison.Decode.transform(
+      body,
+      %{
+        as: %Plaid.IdentityVerification{
+          template: %Plaid.IdentityVerification.Template{},
+          user: %Plaid.IdentityVerification.User{
+            name: %Plaid.IdentityVerification.User.Name{},
+            address: %Plaid.IdentityVerification.User.Address{},
+            id_number: %Plaid.IdentityVerification.User.IDNumber{}
+          },
+          steps: %Plaid.IdentityVerification.Steps{},
+          documentary_verification: %Plaid.IdentityVerification.DocumentaryVerification{
+            documents: [
+              %Plaid.IdentityVerification.DocumentaryVerification.Document{
+                images: [%Plaid.IdentityVerification.DocumentaryVerification.Document.Image{}],
+                redacted_images: [
+                  %Plaid.IdentityVerification.DocumentaryVerification.Document.Image{}
+                ],
+                extracted_data:
+                  %Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedData{
+                    address: %Plaid.IdentityVerification.User.Address{},
+                    name: %Plaid.IdentityVerification.User.Name{}
+                  },
+                analysis: %Plaid.IdentityVerification.DocumentaryVerification.Document.Analysis{}
+              }
+            ]
+          },
+          selfie_check: %Plaid.IdentityVerification.SelfieCheck{
+            capture: [%Plaid.IdentityVerification.SelfieCheck.Capture{}],
+            analysis: %Plaid.IdentityVerification.SelfieCheck.Analysis{}
+          },
+          kyc_check: %Plaid.IdentityVerification.KYCCheck{},
+          risk_check: %Plaid.IdentityVerification.RiskCheck{},
+          watchlist_screening: %Plaid.IdentityVerification.WatchlistScreening{}
+        }
+      }
+    )
+  end
+
+  defp map_list_response(body) do
+    Poison.Decode.transform(
+      body,
+      %{
+        as: %Plaid.IdentityVerification.ListResponse{
+          identity_verifications: [
+            %Plaid.IdentityVerification{
+              template: %Plaid.IdentityVerification.Template{},
+              user: %Plaid.IdentityVerification.User{
+                name: %Plaid.IdentityVerification.User.Name{},
+                address: %Plaid.IdentityVerification.User.Address{},
+                id_number: %Plaid.IdentityVerification.User.IDNumber{}
+              },
+              steps: %Plaid.IdentityVerification.Steps{},
+              documentary_verification: %Plaid.IdentityVerification.DocumentaryVerification{
+                documents: [
+                  %Plaid.IdentityVerification.DocumentaryVerification.Document{
+                    images: [
+                      %Plaid.IdentityVerification.DocumentaryVerification.Document.Image{}
+                    ],
+                    redacted_images: [
+                      %Plaid.IdentityVerification.DocumentaryVerification.Document.Image{}
+                    ],
+                    extracted_data:
+                      %Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedData{
+                        address: %Plaid.IdentityVerification.User.Address{},
+                        name: %Plaid.IdentityVerification.User.Name{}
+                      },
+                    analysis:
+                      %Plaid.IdentityVerification.DocumentaryVerification.Document.Analysis{}
+                  }
+                ]
+              },
+              selfie_check: %Plaid.IdentityVerification.SelfieCheck{
+                capture: [%Plaid.IdentityVerification.SelfieCheck.Capture{}],
+                analysis: %Plaid.IdentityVerification.SelfieCheck.Analysis{}
+              },
+              kyc_check: %Plaid.IdentityVerification.KYCCheck{},
+              risk_check: %Plaid.IdentityVerification.RiskCheck{},
+              watchlist_screening: %Plaid.IdentityVerification.WatchlistScreening{}
+            }
+          ]
+        }
+      }
+    )
+  end
+end

--- a/test/lib/plaid/identity_verification_test.exs
+++ b/test/lib/plaid/identity_verification_test.exs
@@ -1,0 +1,373 @@
+defmodule Plaid.IdentityVerificationTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+  import Plaid.Factory
+
+  setup do
+    verify_on_exit!()
+
+    {:ok,
+     config: %{
+       client: PlaidMock,
+       client_id: "test_id",
+       secret: "test_secret",
+       root_uri: "http://localhost:4000/"
+     }}
+  end
+
+  @moduletag :identity_verification
+
+  @tag :unit
+  test "identity verification data structure encodes with Jason" do
+    assert {:ok, _} =
+             Jason.encode(%Plaid.IdentityVerification{
+               template: %Plaid.IdentityVerification.Template{},
+               user: %Plaid.IdentityVerification.User{
+                 name: %Plaid.IdentityVerification.User.Name{},
+                 address: %Plaid.IdentityVerification.User.Address{},
+                 id_number: %Plaid.IdentityVerification.User.IDNumber{}
+               },
+               steps: %Plaid.IdentityVerification.Steps{},
+               documentary_verification: %Plaid.IdentityVerification.DocumentaryVerification{
+                 documents: [
+                   %Plaid.IdentityVerification.DocumentaryVerification.Document{
+                     images: [
+                       %Plaid.IdentityVerification.DocumentaryVerification.Document.Image{}
+                     ],
+                     extracted_data:
+                       %Plaid.IdentityVerification.DocumentaryVerification.Document.ExtractedData{},
+                     analysis:
+                       %Plaid.IdentityVerification.DocumentaryVerification.Document.Analysis{}
+                   }
+                 ]
+               },
+               selfie_check: %Plaid.IdentityVerification.SelfieCheck{
+                 capture: [%Plaid.IdentityVerification.SelfieCheck.Capture{}],
+                 analysis: %Plaid.IdentityVerification.SelfieCheck.Analysis{}
+               }
+             })
+  end
+
+  describe "identity_verification create/2" do
+    @tag :unit
+    test "submits request and unmarshalls response", %{config: config} do
+      params = %{
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        gave_consent: true,
+        client_user_id: "your-db-id-3b24110"
+      }
+
+      PlaidMock
+      |> expect(:send_request, fn request, _client ->
+        assert request.method == :post
+        assert request.endpoint == "identity_verification/create"
+        assert %{metadata: _} = request.opts
+        {:ok, %Tesla.Env{}}
+      end)
+      |> expect(:handle_response, fn _response, mapper ->
+        body = http_response_body(:identity_verification)
+        {:ok, mapper.(body)}
+      end)
+
+      assert {:ok, ds} = Plaid.IdentityVerification.create(params, config)
+      assert %Plaid.IdentityVerification{} = ds
+      assert ds.id == "idv_52xR9LKo77r1Np"
+      assert ds.status == "success"
+      assert ds.user.email_address == "user@example.com"
+      assert ds.user.name.given_name == "John"
+      assert ds.template.id == "idvtmp_4FrXJvfQU3zGUR"
+    end
+
+    @tag :integration
+    test "success integration test" do
+      bypass = Bypass.open()
+
+      config = %{
+        client_id: "test_id",
+        secret: "test_secret",
+        root_uri: "http://localhost:#{bypass.port}/"
+      }
+
+      params = %{
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        gave_consent: true,
+        client_user_id: "your-db-id-3b24110"
+      }
+
+      body = http_response_body(:identity_verification)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Poison.encode!(body))
+      end)
+
+      assert {:ok, %Plaid.IdentityVerification{}} =
+               Plaid.IdentityVerification.create(params, config)
+    end
+
+    @tag :integration
+    test "error integration test" do
+      bypass = Bypass.open()
+
+      config = %{
+        client_id: "test_id",
+        secret: "test_secret",
+        root_uri: "http://localhost:#{bypass.port}/"
+      }
+
+      params = %{
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        gave_consent: true,
+        client_user_id: "your-db-id-3b24110"
+      }
+
+      body = http_response_body(:error)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(400, Poison.encode!(body))
+      end)
+
+      assert {:error, %Plaid.Error{}} = Plaid.IdentityVerification.create(params, config)
+    end
+  end
+
+  describe "identity_verification get/2" do
+    @tag :unit
+    test "submits request and unmarshalls response", %{config: config} do
+      params = %{identity_verification_id: "idv_52xR9LKo77r1Np"}
+
+      PlaidMock
+      |> expect(:send_request, fn request, _client ->
+        assert request.method == :post
+        assert request.endpoint == "identity_verification/get"
+        assert %{metadata: _} = request.opts
+        {:ok, %Tesla.Env{}}
+      end)
+      |> expect(:handle_response, fn _response, mapper ->
+        body = http_response_body(:identity_verification)
+        {:ok, mapper.(body)}
+      end)
+
+      assert {:ok, ds} = Plaid.IdentityVerification.get(params, config)
+      assert %Plaid.IdentityVerification{} = ds
+      assert ds.id == "idv_52xR9LKo77r1Np"
+      assert ds.steps.kyc_check == "success"
+      assert ds.kyc_check.status == "success"
+      assert ds.documentary_verification.status == "success"
+    end
+
+    @tag :integration
+    test "success integration test" do
+      bypass = Bypass.open()
+
+      config = %{
+        client_id: "test_id",
+        secret: "test_secret",
+        root_uri: "http://localhost:#{bypass.port}/"
+      }
+
+      params = %{identity_verification_id: "idv_52xR9LKo77r1Np"}
+      body = http_response_body(:identity_verification)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Poison.encode!(body))
+      end)
+
+      assert {:ok, %Plaid.IdentityVerification{}} =
+               Plaid.IdentityVerification.get(params, config)
+    end
+
+    @tag :integration
+    test "error integration test" do
+      bypass = Bypass.open()
+
+      config = %{
+        client_id: "test_id",
+        secret: "test_secret",
+        root_uri: "http://localhost:#{bypass.port}/"
+      }
+
+      params = %{identity_verification_id: "idv_52xR9LKo77r1Np"}
+      body = http_response_body(:error)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(400, Poison.encode!(body))
+      end)
+
+      assert {:error, %Plaid.Error{}} = Plaid.IdentityVerification.get(params, config)
+    end
+  end
+
+  describe "identity_verification list/2" do
+    @tag :unit
+    test "submits request and unmarshalls response", %{config: config} do
+      params = %{
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        client_user_id: "your-db-id-3b24110"
+      }
+
+      PlaidMock
+      |> expect(:send_request, fn request, _client ->
+        assert request.method == :post
+        assert request.endpoint == "identity_verification/list"
+        assert %{metadata: _} = request.opts
+        {:ok, %Tesla.Env{}}
+      end)
+      |> expect(:handle_response, fn _response, mapper ->
+        body = http_response_body(:identity_verification_list)
+        {:ok, mapper.(body)}
+      end)
+
+      assert {:ok, ds} = Plaid.IdentityVerification.list(params, config)
+      assert %Plaid.IdentityVerification.ListResponse{} = ds
+      assert length(ds.identity_verifications) == 2
+      assert [first | _] = ds.identity_verifications
+      assert %Plaid.IdentityVerification{} = first
+      assert first.id == "idv_52xR9LKo77r1Np"
+    end
+
+    @tag :integration
+    test "success integration test" do
+      bypass = Bypass.open()
+
+      config = %{
+        client_id: "test_id",
+        secret: "test_secret",
+        root_uri: "http://localhost:#{bypass.port}/"
+      }
+
+      params = %{
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        client_user_id: "your-db-id-3b24110"
+      }
+
+      body = http_response_body(:identity_verification_list)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Poison.encode!(body))
+      end)
+
+      assert {:ok, %Plaid.IdentityVerification.ListResponse{}} =
+               Plaid.IdentityVerification.list(params, config)
+    end
+
+    @tag :integration
+    test "error integration test" do
+      bypass = Bypass.open()
+
+      config = %{
+        client_id: "test_id",
+        secret: "test_secret",
+        root_uri: "http://localhost:#{bypass.port}/"
+      }
+
+      params = %{
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        client_user_id: "your-db-id-3b24110"
+      }
+
+      body = http_response_body(:error)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(400, Poison.encode!(body))
+      end)
+
+      assert {:error, %Plaid.Error{}} = Plaid.IdentityVerification.list(params, config)
+    end
+  end
+
+  describe "identity_verification retry/2" do
+    @tag :unit
+    test "submits request and unmarshalls response", %{config: config} do
+      params = %{
+        client_user_id: "your-db-id-3b24110",
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        strategy: "reset"
+      }
+
+      PlaidMock
+      |> expect(:send_request, fn request, _client ->
+        assert request.method == :post
+        assert request.endpoint == "identity_verification/retry"
+        assert %{metadata: _} = request.opts
+        {:ok, %Tesla.Env{}}
+      end)
+      |> expect(:handle_response, fn _response, mapper ->
+        body = http_response_body(:identity_verification)
+        {:ok, mapper.(body)}
+      end)
+
+      assert {:ok, ds} = Plaid.IdentityVerification.retry(params, config)
+      assert %Plaid.IdentityVerification{} = ds
+      assert ds.id == "idv_52xR9LKo77r1Np"
+      assert ds.client_user_id == "your-db-id-3b24110"
+    end
+
+    @tag :integration
+    test "success integration test" do
+      bypass = Bypass.open()
+
+      config = %{
+        client_id: "test_id",
+        secret: "test_secret",
+        root_uri: "http://localhost:#{bypass.port}/"
+      }
+
+      params = %{
+        client_user_id: "your-db-id-3b24110",
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        strategy: "reset"
+      }
+
+      body = http_response_body(:identity_verification)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Poison.encode!(body))
+      end)
+
+      assert {:ok, %Plaid.IdentityVerification{}} =
+               Plaid.IdentityVerification.retry(params, config)
+    end
+
+    @tag :integration
+    test "error integration test" do
+      bypass = Bypass.open()
+
+      config = %{
+        client_id: "test_id",
+        secret: "test_secret",
+        root_uri: "http://localhost:#{bypass.port}/"
+      }
+
+      params = %{
+        client_user_id: "your-db-id-3b24110",
+        template_id: "idvtmp_4FrXJvfQU3zGUR",
+        strategy: "reset"
+      }
+
+      body = http_response_body(:error)
+
+      Bypass.expect(bypass, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(400, Poison.encode!(body))
+      end)
+
+      assert {:error, %Plaid.Error{}} = Plaid.IdentityVerification.retry(params, config)
+    end
+  end
+end

--- a/test/lib/plaid/identity_verification_test.exs
+++ b/test/lib/plaid/identity_verification_test.exs
@@ -227,7 +227,7 @@ defmodule Plaid.IdentityVerificationTest do
       end)
 
       assert {:ok, ds} = Plaid.IdentityVerification.list(params, config)
-      assert %Plaid.IdentityVerification.ListResponse{} = ds
+      assert %Plaid.IdentityVerification.Verifications{} = ds
       assert length(ds.identity_verifications) == 2
       assert [first | _] = ds.identity_verifications
       assert %Plaid.IdentityVerification{} = first
@@ -257,7 +257,7 @@ defmodule Plaid.IdentityVerificationTest do
         |> Plug.Conn.resp(200, Poison.encode!(body))
       end)
 
-      assert {:ok, %Plaid.IdentityVerification.ListResponse{}} =
+      assert {:ok, %Plaid.IdentityVerification.Verifications{}} =
                Plaid.IdentityVerification.list(params, config)
     end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1753,7 +1753,8 @@ defmodule Plaid.Factory do
         }
       },
       "request_id" => "eYupqX1mZkEuQRx",
-      "warnings" => [%{
+      "warnings" => [
+        %{
           "warning_type" => "ASSET_REPORT_WARNING",
           "warning_code" => "OWNERS_UNAVAILABLE",
           "cause" => %{
@@ -1764,11 +1765,13 @@ defmodule Plaid.Factory do
             "request_id" => "Iam3b",
             "causes" => [],
             "status" => 400,
-            "documentation_url" => "https://plaid.com/docs/api/products/assets/#asset_reportcreate",
+            "documentation_url" =>
+              "https://plaid.com/docs/api/products/assets/#asset_reportcreate",
             "suggested_action" => "Please retry request",
             "item_id" => "eYupqX1mZkEuQRx"
           }
-      }]
+        }
+      ]
     }
   end
 
@@ -1791,11 +1794,13 @@ defmodule Plaid.Factory do
         "total_plaid_connections_count" => 15,
         "is_savings_or_money_market_account" => false
       },
-      "warnings" => [%{
-        "warning_type" => "mock",
-        "warning_code" => "mock",
-        "warning_message" => "mock",
-      }],
+      "warnings" => [
+        %{
+          "warning_type" => "mock",
+          "warning_code" => "mock",
+          "warning_message" => "mock"
+        }
+      ],
       "ruleset" => %{
         "ruleset_key" => "mock",
         "outcome" => "accept"
@@ -1814,5 +1819,162 @@ defmodule Plaid.Factory do
 
   def http_response_body(:signal_prepare) do
     %{"request_id" => "mdqfuVxeoza6mhu"}
+  end
+
+  def http_response_body(:identity_verification) do
+    %{
+      "id" => "idv_52xR9LKo77r1Np",
+      "client_user_id" => "your-db-id-3b24110",
+      "created_at" => "2022-05-01T10:00:00Z",
+      "completed_at" => "2022-05-01T10:15:00Z",
+      "previous_attempt_id" => nil,
+      "shareable_url" => "https://my-idv.plaid.com/v/12345abc",
+      "status" => "success",
+      "template" => %{
+        "id" => "idvtmp_4FrXJvfQU3zGUR",
+        "version" => 1
+      },
+      "user" => %{
+        "email_address" => "user@example.com",
+        "phone_number" => "+1 415 555 0100",
+        "date_of_birth" => "1990-01-01",
+        "ip_address" => "192.0.2.42",
+        "name" => %{
+          "given_name" => "John",
+          "family_name" => "Doe"
+        },
+        "address" => %{
+          "street" => "123 Main St",
+          "street2" => "Apt 4",
+          "city" => "San Francisco",
+          "region" => "CA",
+          "postal_code" => "94108",
+          "country" => "US"
+        },
+        "id_number" => %{
+          "value" => "123456789",
+          "type" => "us_ssn"
+        }
+      },
+      "steps" => %{
+        "accept_tos" => "success",
+        "verify_sms" => "success",
+        "kyc_check" => "success",
+        "documentary_verification" => "success",
+        "selfie_check" => "success",
+        "watchlist_screening" => "success",
+        "risk_check" => "success"
+      },
+      "documentary_verification" => %{
+        "status" => "success",
+        "documents" => [
+          %{
+            "status" => "success",
+            "attempt" => 1,
+            "images" => [
+              %{
+                "url" => "https://assets.plaid.com/identity_verification/documents/12345.jpg",
+                "capture_method" => "upload"
+              }
+            ],
+            "extracted_data" => %{
+              "date_of_birth" => "1990-01-01",
+              "expiration_date" => "2025-12-31",
+              "issued_date" => "2020-01-01",
+              "issuing_country" => "US",
+              "id_number" => "D1234567",
+              "category" => "drivers_license",
+              "address" => %{
+                "street" => "123 Main St",
+                "street2" => nil,
+                "city" => "San Francisco",
+                "region" => "CA",
+                "postal_code" => "94108",
+                "country" => "US"
+              },
+              "name" => %{
+                "given_name" => "John",
+                "family_name" => "Doe"
+              }
+            },
+            "analysis" => %{
+              "authenticity" => "pass",
+              "image_quality" => "pass",
+              "extracted_data" => "pass"
+            },
+            "redacted_images" => [
+              %{
+                "url" =>
+                  "https://assets.plaid.com/identity_verification/documents/12345_redacted.jpg",
+                "capture_method" => "upload"
+              }
+            ]
+          }
+        ]
+      },
+      "selfie_check" => %{
+        "status" => "success",
+        "attempt" => 1,
+        "capture" => [
+          %{
+            "url" => "https://assets.plaid.com/identity_verification/selfie/12345.jpg",
+            "video_url" => nil,
+            "capture_method" => "selfie"
+          }
+        ],
+        "analysis" => %{
+          "face_match" => "pass",
+          "image_quality" => "pass"
+        }
+      },
+      "kyc_check" => %{
+        "status" => "success",
+        "address" => "match",
+        "name" => "match",
+        "date_of_birth" => "match",
+        "id_number" => "match",
+        "phone_number" => "match"
+      },
+      "risk_check" => %{
+        "status" => "success",
+        "risk_score" => 15,
+        "linked_services" => ["email", "phone"],
+        "behavior" => %{
+          "is_velocity_high" => false
+        },
+        "email" => %{
+          "is_deliverable" => true
+        },
+        "phone" => %{
+          "is_valid" => true
+        }
+      },
+      "watchlist_screening" => %{
+        "status" => "cleared",
+        "audit_trail" =>
+          "https://dashboard.plaid.com/activity/identity-verification/idv_52xR9LKo77r1Np",
+        "search_terms" => %{
+          "country" => "US",
+          "legal_name" => "John Doe",
+          "date_of_birth" => "1990-01-01"
+        }
+      },
+      "request_id" => "45QSn"
+    }
+  end
+
+  def http_response_body(:identity_verification_list) do
+    %{
+      "identity_verifications" => [
+        http_response_body(:identity_verification),
+        Map.merge(http_response_body(:identity_verification), %{
+          "id" => "idv_52xR9LKo77r1Nq",
+          "status" => "pending",
+          "completed_at" => nil
+        })
+      ],
+      "next_cursor" => "eyJkaXJlY3Rpb24iOiJuZXh0Iiwib2Zmc2V0IjoiMTU5NDM",
+      "request_id" => "45QSn"
+    }
   end
 end


### PR DESCRIPTION
## Summary

This PR adds support for Plaid's Identity Verification product to the library.

## Changes

- **New module**: `Plaid.IdentityVerification` with complete API support
  - `create/2` - Create a new identity verification
  - `get/2` - Retrieve verification details  
  - `list/2` - List verifications with pagination
  - `retry/2` - Retry a verification attempt

- **Data structures**: Comprehensive structs for all verification response types including:
  - Template, User (Name, Address, IDNumber)
  - Steps with all verification stages
  - DocumentaryVerification with document analysis
  - SelfieCheck with facial verification
  - KYCCheck, RiskCheck, WatchlistScreening
  - ListResponse for pagination

- **Test coverage**: Full test suite with 13 tests
  - Unit tests using Mox for behavior mocking
  - Integration tests using Bypass for HTTP simulation
  - Both success and error scenarios covered

- **Test fixtures**: Added factory functions for identity verification responses

## Implementation Notes

- Follows all existing library patterns and conventions
- Uses the same testing approach as other products
- All structs derive Jason.Encoder for serialization
- Complete type specifications for Dialyzer
- Documentation links to official Plaid API docs

## Testing

All 157 tests pass including the 13 new identity verification tests.